### PR TITLE
Added Error Handling on ED Log Path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -329,6 +329,31 @@ ASALocalRun/
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
 
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
 # Ignore local folders
 systems/
 edlogs/

--- a/Program.cs
+++ b/Program.cs
@@ -12,21 +12,90 @@ namespace EdGps
         public static void Main(string[] args) {
             if (!Directory.Exists(Directories.SystemDir)) Directory.CreateDirectory(Directories.SystemDir);
 
-            Console.WriteLine("Please specify the directory where E:D Journal logs are kept. You may drag & drop if possible");
-            var directoryPath = "";
-            var input = "";
+            //Check if user has already set a path
+            // NOTE: This should be changed to some common config file, like a config.INI or something for future use
+            string edLogDirectoryFile = Path.Join(System.AppContext.BaseDirectory, "userdirectory.txt");
 
-            while (true) {
-                Console.Write("Path:");
-                input = Console.ReadLine();
+            string directoryPath = null;
+            string exittext = "\nPress any key to exit...";
 
-                if (input.Length < 1) continue;
+            try
+            {
+                if (File.Exists(edLogDirectoryFile))
+                {
+                    directoryPath = File.ReadAllText(edLogDirectoryFile);
+                }
+                else
+                {
+                    Console.WriteLine("\n\nE:D Journal Log Directory (e.g. C:\\Users\\<username>\\Saved Games\\Frontier Developments\\Elite Dangerous) :\n");
+                    directoryPath = Console.ReadLine()
+                        .Replace('\'', ' ')
+                        .Replace('&', ' ')
+                        .TrimStart(' ')
+                        .TrimEnd(' ');
 
-                directoryPath = Parser.ParseDirectoryPath(input);
-                if (Directory.Exists(directoryPath)) break;
-                
-                Console.WriteLine("Unable to find directory! Please try again.");
+                    if (directoryPath.Length <= 4)
+                    {
+                        Console.WriteLine("Please specify the directory where E:D Journal logs are kept.");
+                        Console.WriteLine(exittext);
+                        Console.ReadKey();
+                        return;
+                    }
+                }
             }
+            catch (Exception e)
+            {
+                Console.WriteLine("Error: " + e);
+                Console.WriteLine(exittext);
+                Console.ReadKey();
+                return;
+            }
+
+            //Some user error handling
+            try
+            {
+                if (!(Directory.Exists(directoryPath)))
+                {
+                    throw new Exception("\nError: Directory does not exist.\n");
+                }
+                if (Directory.GetFiles(directoryPath).Length <= 0)
+                {
+                    throw new Exception("\nError: Directory has no files.\n");
+                }
+                bool islogfile = false;
+                foreach (string file in Directory.GetFiles(directoryPath))
+                {
+                    if (file.EndsWith(".log"))
+                    {
+                        islogfile = true;
+                    }
+                }
+                if (!islogfile)
+                {
+                    throw new Exception("\nError: Directory has no *.log files.\n");
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Error: " + e);
+                Console.WriteLine("\nPlease retry...");
+                Main(null);
+            }
+
+            //Save Path if legit
+            try
+            {
+                File.WriteAllText(edLogDirectoryFile, directoryPath);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Error: " + e);
+                Console.WriteLine(exittext);
+                Console.ReadKey();
+                return;
+            }
+
+            // If everything's okay, move on
 
             new Program().StartAsync(directoryPath).GetAwaiter().GetResult();
         }


### PR DESCRIPTION
.gitignore
---
+ Added WINDOWS enviroment to be handled

EDGPS
---
+ Added Error handling on ED Log path input from user
+ If user Log path seems correct (checks if *.log files are actually there), path is saved to TXT file for later use
+ Reuse of saved path on startup

TBD:
Acutal user-settings file for future use of common-settings from users, like an INI.